### PR TITLE
Add helpers script and update modules

### DIFF
--- a/modules/00_SysUp.sh
+++ b/modules/00_SysUp.sh
@@ -5,18 +5,20 @@ if grep -q "UPDATE_DONE=true" settings.txt; then
   exit 0
 fi
 
+LOG_FILE="sump_logfile.log"
+source ui/helpers.sh
+
 echo "Mise à jour du système en cours..."
 apt update && apt full-upgrade -y
 
 # Ajouter une ligne dans les logs
-echo "$(date '+%F %T') - Système mis à jour." >> sump_logfile.log
+log_msg "Système mis à jour."
 
 # Marquer l'étape comme terminée
 echo "UPDATE_DONE=true" >> settings.txt
 
 # Demander à redémarrer
-read -p "Redémarrer maintenant pour appliquer les mises à jour ? [O/n] " REBOOT
-if [[ "$REBOOT" =~ ^[OoYy]?$ ]]; then
+if confirm_prompt "Redémarrer maintenant pour appliquer les mises à jour ?"; then
   touch /tmp/sump_autorestart.flag
   reboot
 fi

--- a/modules/02_Sec_Host.sh
+++ b/modules/02_Sec_Host.sh
@@ -7,10 +7,7 @@ set -e
 
 LOG_FILE="logs/sump.log"
 SETTINGS="settings.txt"
-
-log() {
-  echo "$(date +'%F %T') - $1" | tee -a "$LOG_FILE"
-}
+source ui/helpers.sh
 
 # 🔁 Charger le port SSH si défini
 if grep -q "^SSH_PORT=" "$SETTINGS"; then
@@ -20,12 +17,12 @@ else
   echo "SSH_PORT=$SSH_PORT" >> "$SETTINGS"
 fi
 
-log "[SECURITY] Début de configuration de la sécurité système."
+log_msg "[SECURITY] Début de configuration de la sécurité système."
 
 echo "Installation de fail2ban et ufw..."
 apt install -y fail2ban ufw
 
-log "Services installés."
+log_msg "Services installés."
 
 # 🧱 Configuration fail2ban minimaliste
 cat <<EOF > /etc/fail2ban/jail.local
@@ -37,28 +34,27 @@ maxretry = 5
 bantime = 3600
 EOF
 
-log "Fichier /etc/fail2ban/jail.local créé."
+log_msg "Fichier /etc/fail2ban/jail.local créé."
 
 systemctl enable fail2ban
 systemctl restart fail2ban
-log "fail2ban activé et redémarré."
+log_msg "fail2ban activé et redémarré."
 
 # 🔥 Configuration UFW
 ufw default deny incoming
 ufw default allow outgoing
 ufw allow $SSH_PORT/tcp
-log "Pare-feu UFW : trafic entrant bloqué sauf SSH ($SSH_PORT)."
+log_msg "Pare-feu UFW : trafic entrant bloqué sauf SSH ($SSH_PORT)."
 
 # Optionnel : autoriser web
-read -rp "Souhaites-tu autoriser HTTP (80) et HTTPS (443) ? [O/n] : " ALLOW_WEB
-if [[ "$ALLOW_WEB" =~ ^[OoYy]?$ ]]; then
+if confirm_prompt "Souhaites-tu autoriser HTTP (80) et HTTPS (443) ?"; then
   ufw allow 80/tcp
   ufw allow 443/tcp
-  log "Ports HTTP et HTTPS autorisés."
+  log_msg "Ports HTTP et HTTPS autorisés."
 fi
 
 ufw --force enable
-log "Pare-feu UFW activé."
+log_msg "Pare-feu UFW activé."
 
 echo
 echo "✅ Sécurité réseau configurée : fail2ban actif, UFW actif."

--- a/modules/03_BasFig.sh
+++ b/modules/03_BasFig.sh
@@ -7,16 +7,13 @@ set -e
 
 LOG_FILE="logs/sump.log"
 SETTINGS="settings.txt"
-
-log() {
-  echo "$(date +'%F %T') - $1" | tee -a "$LOG_FILE"
-}
+source ui/helpers.sh
 
 # Changement du nom d'hôte
 read -rp "Nom à donner au serveur (ex: monserveur) : " HOSTNAME
 echo "$HOSTNAME" > /etc/hostname
 sed -i "s/127.0.1.1.*/127.0.1.1\t$HOSTNAME/" /etc/hosts
-log "Nom du serveur changé en $HOSTNAME"
+log_msg "Nom du serveur changé en $HOSTNAME"
 echo "HOSTNAME=$HOSTNAME" >> "$SETTINGS"
 
 # Choix d'une interface
@@ -39,13 +36,13 @@ static routers=$GATEWAY
 static domain_name_servers=$DNS
 EOF
 
-log "IP statique configurée sur $IFACE ($IP)"
+log_msg "IP statique configurée sur $IFACE ($IP)"
 echo "INTERFACE=$IFACE" >> "$SETTINGS"
 echo "STATIC_IP=$IP" >> "$SETTINGS"
 
 # Redémarrage du service réseau
 systemctl restart dhcpcd
-log "Redémarrage de dhcpcd"
+log_msg "Redémarrage de dhcpcd"
 
 echo
 echo "Configuration terminée."

--- a/modules/04_DynIp.sh
+++ b/modules/04_DynIp.sh
@@ -7,10 +7,7 @@ set -e
 
 LOG_FILE="logs/sump.log"
 SETTINGS="settings.txt"
-
-log() {
-  echo "$(date +'%F %T') - $1" | tee -a "$LOG_FILE"
-}
+source ui/helpers.sh
 
 echo
 echo "Configuration d’un service DNS dynamique (IP fixe virtuelle)"
@@ -35,13 +32,13 @@ echo url="https://www.duckdns.org/update?domains=$DUCK_SUBDOMAIN&token=$DUCK_TOK
 EOF
 
 chmod +x "$DUCK_SCRIPT"
-log "Script DuckDNS créé à $DUCK_SCRIPT"
+log_msg "Script DuckDNS créé à $DUCK_SCRIPT"
 
 # Créer tâche cron toutes les 5 minutes
 CRON_FILE="/etc/cron.d/duckdns"
 echo "*/5 * * * * root $DUCK_SCRIPT > /dev/null 2>&1" > "$CRON_FILE"
 
-log "Tâche cron créée pour mettre à jour l’IP DuckDNS toutes les 5 minutes."
+log_msg "Tâche cron créée pour mettre à jour l’IP DuckDNS toutes les 5 minutes."
 
 echo
 echo "✅ DuckDNS est configuré et actif."

--- a/ui/helpers.sh
+++ b/ui/helpers.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# ui/helpers.sh - Common helper functions for SetUpMyPi scripts
+
+# Default log file location
+LOG_FILE="${LOG_FILE:-logs/sump.log}"
+
+# Log a message with timestamp
+log_msg() {
+  local msg="$1"
+  mkdir -p "$(dirname "$LOG_FILE")"
+  echo "$(date +'%F %T') - $msg" | tee -a "$LOG_FILE"
+}
+
+# Prompt the user for confirmation. Return 0 for yes, 1 for no.
+confirm_prompt() {
+  local prompt="$1"
+  if [[ $INTERFACE_MODE == "dialog" ]] && command -v dialog &>/dev/null; then
+    dialog --clear --stdout --yesno "$prompt" 7 60
+    return $?
+  else
+    local resp
+    read -rp "$prompt [O/n] " resp
+    [[ "$resp" =~ ^([OoYy]|)$ ]]
+    return $?
+  fi
+}


### PR DESCRIPTION
## Summary
- create `ui/helpers.sh` with `log_msg` and `confirm_prompt`
- use helper functions across module scripts

## Testing
- `bash -n ui/helpers.sh modules/01_Sec_SSH.sh modules/02_Sec_Host.sh modules/03_BasFig.sh modules/04_DynIp.sh modules/00_SysUp.sh`

------
https://chatgpt.com/codex/tasks/task_e_68839c472f6c832ca3a7eed6b53e8152

## Résumé par Sourcery

Introduction d'un script d'aide partagé pour la journalisation centralisée et les invites utilisateur, et refonte de tous les scripts de module pour tirer parti de ces aides pour des messages de journalisation et des invites de confirmation cohérents.

Nouvelles fonctionnalités :
- Ajout de ui/helpers.sh fournissant `log_msg` pour la journalisation horodatée et `confirm_prompt` pour les confirmations utilisateur standardisées.

Améliorations :
- Refonte de tous les modules pour sourcer ui/helpers.sh et remplacer les fonctions de journalisation intégrées par `log_msg`
- Utilisation de `confirm_prompt` dans les scripts pour les invites interactives au lieu d'une gestion manuelle de lecture/regex
- Unification de la gestion par défaut des fichiers journaux dans tous les scripts de configuration via la variable partagée `LOG_FILE`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a shared helper script for centralized logging and user prompts, and refactor all module scripts to leverage these helpers for consistent log messages and confirmation prompts.

New Features:
- Add ui/helpers.sh providing log_msg for timestamped logging and confirm_prompt for standardized user confirmations.

Enhancements:
- Refactor all modules to source ui/helpers.sh and replace inline log functions with log_msg
- Use confirm_prompt in scripts for interactive prompts instead of manual read/regex handling
- Unify default log file handling across all setup scripts via the shared LOG_FILE variable

</details>